### PR TITLE
Circulair prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,24 @@ Duration is how long it takes do one cycle of the skeleton animation.
 
 Width of the skeleton. Useful when the skeleton is inside an inline element with
 no width of its own.
+
+## Height
+
+`Height`: Number | String | null, defaults to null
+
+```javascript
+<Skeleton height={100} />
+```
+
+Height of the skeleton. Useful when you don't want to adapt the skeleton to a text element but for instance
+a card. Also needed for the prop `circle` (see below).
+
+## Circle
+
+`Circle`: Boolean | false, defaults to false
+
+```javascript
+<Skeleton circle={true} height={50} width={50} />
+```
+
+Prop for making the skeleton look like a circle, for when you are creating a user card with a profile picture for instance.

--- a/src/skeleton.js
+++ b/src/skeleton.js
@@ -36,7 +36,8 @@ export default class Skeleton extends Component {
     duration: 1.2,
     width: null,
     wrapper: null,
-    height: null
+    height: null,
+    circle: false
   };
 
   render() {
@@ -53,6 +54,9 @@ export default class Skeleton extends Component {
       }
       if (this.props.height != null) {
         style.height = this.props.height;
+      }
+      if (this.props.width !== null && this.props.height !== null && this.props.circle) {
+        style.borderRadius = '50%';
       }
       elements.push(
         <span key={i} className={skeletonClass} style={style}>

--- a/src/skeleton.js
+++ b/src/skeleton.js
@@ -35,7 +35,8 @@ export default class Skeleton extends Component {
     count: 1,
     duration: 1.2,
     width: null,
-    wrapper: null
+    wrapper: null,
+    height: null
   };
 
   render() {
@@ -49,6 +50,9 @@ export default class Skeleton extends Component {
       };
       if (this.props.width != null) {
         style.width = this.props.width;
+      }
+      if (this.props.height != null) {
+        style.height = this.props.height;
       }
       elements.push(
         <span key={i} className={skeletonClass} style={style}>

--- a/stories/Skeleton.story.js
+++ b/stories/Skeleton.story.js
@@ -62,7 +62,7 @@ storiesOf("Skeleton", module)
     <div style={{ display: "flex", flexDirection: "column" }}>
       <Skeleton count={1} />
       <Skeleton count={1} height={200} />
-      <Skeleton count={1} width={400} />
-      <Skeleton count={1} width={600} />
+      <Skeleton count={1} height={400} />
+      <Skeleton count={1} height={600} />
     </div>
   ));

--- a/stories/Skeleton.story.js
+++ b/stories/Skeleton.story.js
@@ -65,4 +65,9 @@ storiesOf("Skeleton", module)
       <Skeleton count={1} height={400} />
       <Skeleton count={1} height={600} />
     </div>
+  ))
+  .add("Skeleton displayed as circle", () => (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <Skeleton count={1} height={50} width={50} circle={true} />
+    </div>
   ));

--- a/stories/Skeleton.story.js
+++ b/stories/Skeleton.story.js
@@ -57,4 +57,12 @@ storiesOf("Skeleton", module)
       <Skeleton count={1} width={100} />
       <Skeleton count={1} width={200} />
     </div>
+  ))
+  .add("with different heights", () => (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <Skeleton count={1} />
+      <Skeleton count={1} height={200} />
+      <Skeleton count={1} width={400} />
+      <Skeleton count={1} width={600} />
+    </div>
   ));


### PR DESCRIPTION
Based on open issue #9 I've added a small feature to make the skeleton circulair. This will make it easy to compose for example user cards with profile pictures. To make this work I also added a height prop to manage the height of the skeleton. This default prop will be null so this won't affect `skeletons` that are used by adapting to text.

The reason why I added these props is because this package now is only supporting skeleton loading for texts. Imho, most of the time it's not text you would like to cover with skeleton loading.

I've added stories to the tests. Please make sure to also update the npm package when this PR get's accepted since I would like to use this package heavily.