### PR TITLE
Fix width and height type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,8 +5,8 @@ export default class Skeleton extends Component<Props> {}
 interface Props {
   count?: number;
   duration?: number;
-  width?: string;
+  width?: number;
   wrapper?: ReactNode;
-  height?: string;
+  height?: number;
   circle?: boolean;
 }


### PR DESCRIPTION
Currently, the types for `width` and `height` expect a string, but it should be a number. The prop only works with numbers as well.