### PR TITLE
Dynamic SkeletonTheme at runtime

### DIFF
--- a/src/skeleton-theme.js
+++ b/src/skeleton-theme.js
@@ -8,23 +8,19 @@ export default class SkeletonTheme extends Component {
     highlightColor: defaultHighlightColor
   };
 
-  constructor(props) {
-    super(props);
-
-    this.themeClass = css`
+  render() {
+    const { color, highlightColor, children } = this.props;
+    const themeClass = css`
       .react-loading-skeleton {
-        background-color: ${props.color};
+        background-color: ${color};
         background-image: linear-gradient(
           90deg,
-          ${props.color},
-          ${props.highlightColor},
-          ${props.color}
+          ${color},
+          ${highlightColor},
+          ${color}
         );
       }
     `;
-  }
-
-  render() {
-    return <div className={this.themeClass}>{this.props.children}</div>;
+    return <div className={themeClass}>{children}</div>;
   }
 }

--- a/stories/Skeleton.story.js
+++ b/stories/Skeleton.story.js
@@ -42,6 +42,37 @@ storiesOf("Skeleton", module)
       </div>
     </SideBySide>
   ))
+  .add("with dynamic theme", () => {
+    const [theme, setTheme] = React.useState("light");
+    const skeletonColor =
+      theme === "light" ? "rgba(0, 0, 0, .1)" : "rgba(255, 255, 255, .1)";
+    const skeletonHighlight =
+      theme === "light" ? "rgba(0, 0, 0, .2)" : "rgba(255,255,255, .2)";
+
+    const handleToggle = () => {
+      setTheme(oldTheme => (oldTheme === "light" ? "dark" : "light"));
+    };
+
+    const backgroundColor = theme === "light" ? "white" : "#222";
+
+    return (
+      <div style={{ backgroundColor }}>
+        <button onClick={handleToggle}>Toggle Theme</button>
+        <SideBySide>
+          <SkeletonTheme
+            color={skeletonColor}
+            highlightColor={skeletonHighlight}
+          >
+            <Skeleton count={5} wrapper={Box} />
+          </SkeletonTheme>
+          <div>
+            <Box key={1}>A</Box>
+            <Box key={2}>B</Box>
+          </div>
+        </SideBySide>
+      </div>
+    );
+  })
   .add("with different durations", () => (
     <div>
       <Skeleton count={1} duration={1} />


### PR DESCRIPTION
Howdy @dvtng!
 
Fixes https://github.com/dvtng/react-loading-skeleton/issues/36

Currently, the values passed to `SkeletonTheme` cannot be changed at runtime, since the overarching `themeClass` style (which governs how the child `Skeleton` components appear) is getting built _once_ in a constructor function.

This PR moves that style construction logic to the render function of `SkeletonTheme` to be more idiomatically "React-y" (where props drive dynamic component behavior) and adds an example Storybook story accordingly.

Let me know if there are questions!
❤️ 