### PR TITLE
Update skeleton.js

### DIFF
--- a/src/skeleton.js
+++ b/src/skeleton.js
@@ -26,6 +26,7 @@ export const skeletonStyles = css`
   background-repeat: no-repeat;
   border-radius: 4px;
   display: inline-block;
+  vertical-align: top;
   line-height: 1;
   width: 100%;
 `;


### PR DESCRIPTION
fix: #70 make Skeleton <span> not to be affected by wrapper's line-height so that vertical-align looks well :)
(no need to change your wrapper's line-height to be 1)