### PR TITLE
Added containerClassName to allow <span> container to be customised

### DIFF
--- a/src/skeleton.js
+++ b/src/skeleton.js
@@ -39,6 +39,7 @@ export default function Skeleton({
   circle,
   style: customStyle,
   className: customClassName,
+  containerClassName
 }) {
   const elements = [];
 
@@ -81,7 +82,7 @@ export default function Skeleton({
   }
 
   return (
-    <span>
+    <span className={containerClassName}>
       {Wrapper
         ? elements.map((element, i) => (
             <Wrapper key={i}>
@@ -101,4 +102,5 @@ Skeleton.defaultProps = {
   wrapper: null,
   height: null,
   circle: false,
+  containerClassName: ""
 };


### PR DESCRIPTION
Added containerClassName option to allow the wrapping <span> tag to be customised. In my particular case, I'm using this to fix the issue with 100% width Skeletons not to display (has a width of 0px).