### PR TITLE
perf: use composite animation

### DIFF
--- a/src/Skeleton.tsx
+++ b/src/Skeleton.tsx
@@ -21,11 +21,11 @@ function styleOptionsToCssProperties({
     duration,
     enableAnimation = true,
 }: SkeletonStyleProps & { circle: boolean }): CSSProperties {
-    const style: CSSProperties = {}
+    const style: CSSProperties & Record<`--${string}`, string> = {}
 
-    if (direction === 'rtl') style.animationDirection = 'reverse'
+    if (direction === 'rtl') style['--animation-direction'] = 'reverse'
 
-    if (typeof duration === 'number') style.animationDuration = `${duration}s`
+    if (typeof duration === 'number') style['--animation-duration'] = `${duration}s`
 
     if (typeof width === 'string' || typeof width === 'number') style.width = width
     if (typeof height === 'string' || typeof height === 'number') style.height = height
@@ -42,13 +42,8 @@ function styleOptionsToCssProperties({
     }
 
     if (typeof baseColor !== 'undefined' || typeof highlightColor !== 'undefined') {
-        style.backgroundColor = baseColor ?? defaultBaseColor
-        style.backgroundImage = `linear-gradient(
-            90deg,
-            ${baseColor ?? defaultBaseColor},
-            ${highlightColor ?? defaultHighlightColor},
-            ${baseColor ?? defaultBaseColor}
-        )`
+        style['--base-color'] = baseColor ?? defaultBaseColor;
+        style['--highlight-color'] = highlightColor ?? defaultHighlightColor;
     }
 
     if (!enableAnimation) style.backgroundImage = 'none'

--- a/src/skeleton.css
+++ b/src/skeleton.css
@@ -8,6 +8,8 @@
     /* If either color is changed, Skeleton.tsx must be updated as well */
     --base-color: #ebebeb;
     --highlight-color: #f5f5f5;
+    --animation-duration: 1.5s;
+    --animation-direction: normal;
 
     background-color: var(--base-color);
 
@@ -37,7 +39,8 @@
     transform: translateX(-100%);
 
     animation-name: react-loading-skeleton;
-    animation-duration: 1.5s;
+    animation-direction: var(--animation-direction);
+    animation-duration: var(--animation-duration);
     animation-timing-function: ease-in-out;
     animation-iteration-count: infinite;
 }


### PR DESCRIPTION
Skeleton is animated using css tranform instead of background repositioning. Previously, changing background position caused the renderer to repaint the gradient on each animation keyframe.

This implementation uses translateX to animate the skeleton effect. Using css transform doesn't trigger repaint.

Before

https://user-images.githubusercontent.com/7829141/136707209-22fb8843-700f-475f-9e77-4cf91f23de02.mov

After

https://user-images.githubusercontent.com/7829141/136707245-df707021-9aa4-4ace-8af4-f26ae23f4a51.mov


