### PR TITLE
Add useSkeleton hook, docs & storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,7 +4,7 @@ import '../src/skeleton.css'
 export const parameters = {
     options: {
         storySort: {
-            order: ['Skeleton', 'SkeletonTheme', 'Post'],
+            order: ['Skeleton', 'UseSkeleton', 'SkeletonTheme', 'Post'],
         },
     },
     actions: { argTypesRegex: '^on[A-Z].*' },

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ return (
         <tr>
             <td><code>count?: number</code></td>
             <td>
-                The number of lines of skeletons to render. If 
+                The number of lines of skeletons to render. If
                 <code>count</code> is a decimal number like 3.5,
                 three full skeletons and one half-width skeleton will be
                 rendered.
@@ -288,6 +288,32 @@ This is a consequence of how `line-height` works in CSS. If you need the `<div>`
 to be exactly 30px tall, set its `line-height` to 1. [See
 here](https://github.com/dvtng/react-loading-skeleton/issues/23#issuecomment-939231878)
 for more details.
+
+### The `useSkeleton` hook
+
+A `useSkeleton` hook encapsulates conditional logic to keep your code easier to
+read.
+
+```tsx
+// Assuming a variable or prop exists with the loading state, use the
+// hook to get `withSkeleton`
+const { withSkeleton } = useSkeleton(loading)
+
+// A skeleton is rendered in place of `value` if `loading` is truthy
+<TableCell>{withSkeleton(value)}</TableCell>
+```
+
+If needed, skeleton options can be provided to `useSkeleton`
+
+```tsx
+const { withSkeleton } = useSkeleton(loading, { round: true })
+```
+
+...or via `withSkeleton()`
+
+```tsx
+<TableCell>{withSkeleton(value, { count: 4 })}</TableCell>
+```
 
 ## Contributing
 

--- a/src/__stories__/Skeleton.stories.tsx
+++ b/src/__stories__/Skeleton.stories.tsx
@@ -327,12 +327,12 @@ export const ShadowDOM: React.FC = () => {
             background-position: calc(200px + 100%) 0;
         }
     }
-    
+
     .react-loading-skeleton {
         /* If either color is changed, Skeleton.tsx must be updated as well */
         --base-color: #ebebeb;
         --highlight-color: #f5f5f5;
-    
+
         background-color: var(--base-color);
         background-image: linear-gradient(
             90deg,
@@ -340,19 +340,19 @@ export const ShadowDOM: React.FC = () => {
             var(--highlight-color),
             var(--base-color)
         );
-    
+
         width: 100%;
         background-size: 200px 100%;
         background-repeat: no-repeat;
         border-radius: 0.25rem;
         display: inline-block;
         line-height: 1;
-    
+
         animation-name: react-loading-skeleton;
         animation-duration: 1.5s;
         animation-timing-function: ease-in-out;
         animation-iteration-count: infinite;
-    }    
+    }
     `
 
     const shadowContent = (

--- a/src/__stories__/UseSkeleton.stories.tsx
+++ b/src/__stories__/UseSkeleton.stories.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useCallback } from 'react'
+import { Meta } from '@storybook/react'
+import { SideBySide } from './components'
+import './styles/Skeleton.stories.css'
+import { useSkeleton } from '../useSkeleton'
+
+export default {
+    title: 'useSkeleton',
+} as Meta
+
+const FourthDiv = () => <>Fourth Div</>
+
+export const UseSkeletonHook: React.FC = () => {
+    const [loading, setLoading] = useState(true)
+    const toggleLoading = useCallback(() => setLoading((prev) => !prev), [])
+    const { withSkeleton } = useSkeleton(loading)
+    return (
+        <SideBySide>
+            <button type="button" onClick={toggleLoading}>
+                Toggle Loading State
+            </button>
+            <div>
+                <div style={{ width: 100 }}>{withSkeleton('First Div')}</div>
+                <div style={{ width: 150 }}>{withSkeleton('Second Div')}</div>
+                <div style={{ width: 75 }}>{withSkeleton(<div>Third Div</div>)}</div>
+                <div style={{ width: 150 }}>{withSkeleton(<FourthDiv />)}</div>
+            </div>
+        </SideBySide>
+    )
+}
+
+export const UseSkeletonHookProps: React.FC = () => {
+    const [loading, setLoading] = useState(true)
+    const toggleLoading = useCallback(() => setLoading((prev) => !prev), [])
+    // Sets SkeletonProps: `circle` for all instances of `withSkeleton`
+    const { withSkeleton } = useSkeleton(loading, {circle: true, width: '1em'})
+    return (
+        <SideBySide>
+            <button type="button" onClick={toggleLoading}>
+                Toggle Loading State
+            </button>
+            <div>
+                <div>{withSkeleton('1em')}</div>
+                <div>{withSkeleton('1em')}</div>
+                {/* Override width this time only */}
+                <div>{withSkeleton('4em', {width: '4em'})}</div>
+                <div>{withSkeleton('1em')}</div>
+            </div>
+        </SideBySide>
+    )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ import { Skeleton } from './Skeleton'
 export default Skeleton
 export * from './SkeletonStyleProps'
 export * from './SkeletonTheme'
+export * from './useSkeleton'
 export type { SkeletonProps } from './Skeleton'

--- a/src/useSkeleton.tsx
+++ b/src/useSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { ReactNode } from 'react'
+import type { SkeletonProps } from './Skeleton'
+import { Skeleton } from './Skeleton'
+
+const emptyProps: SkeletonProps = {}
+
+/**
+ * Returns `withSkeleton` which conditionally returns a loading skeleton in place of contents
+ */
+export const useSkeleton = (loading: boolean, defaultProps = emptyProps) =>
+    React.useMemo(
+        () => ({
+            withSkeleton: <T extends ReactNode>(arg: T, props = emptyProps) =>
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                loading ? <Skeleton {...defaultProps} {...props} /> : arg,
+        }),
+        [defaultProps, loading]
+    )


### PR DESCRIPTION
This PR adds a new `useSkeleton` hook. 

Although tiny, this hook has a dramatic impact on the developer experience.  This hook is a trivially small monad wrapper around a ternary: rendering either `children` or a skeleton, depending on the hook's `isLoading` argument.

## This PR adds a `Use Skeleton Hook` storybook story:
![Screenshot](https://user-images.githubusercontent.com/9967320/175826527-06e6012a-8e42-4066-9337-30329f47fc31.gif)



## This PR adds the following to `README.md` 

### The `useSkeleton` hook

A `useSkeleton` hook encapsulates conditional logic to keep your code easier to
read.

```tsx
// Assuming a variable or prop exists with the loading state, use the
// hook to get `withSkeleton`
const { withSkeleton } = useSkeleton(loading)

// A skeleton is rendered in place of `value` if `loading` is truthy
<TableCell>{withSkeleton(value)}</TableCell>
```

If needed, skeleton options can be provided to `useSkeleton`

```tsx
const { withSkeleton } = useSkeleton(loading, { round: true })
```

...or via `withSkeleton()`

```tsx
<TableCell>{withSkeleton(value, { count: 4 })}</TableCell>
```
