### PR TITLE
Fix an issue that does not render Skeleton when width param is nullable

### DIFF
--- a/src/Skeleton.tsx
+++ b/src/Skeleton.tsx
@@ -96,6 +96,14 @@ export function Skeleton({
   let className = 'react-loading-skeleton';
   if (customClassName) className += ` ${customClassName}`;
 
+  let containerStyle;
+  // eslint-disable-next-line eqeqeq
+  if (style.width == undefined || style.width === '100%') {
+    // if style.width is undefined | null | '100%'
+    // we need to add width:100% to the container span element.
+    containerStyle = { width: '100%' };
+  }
+
   const inline = styleOptions.inline ?? false;
 
   const elements: ReactElement[] = [];
@@ -151,6 +159,7 @@ export function Skeleton({
       data-testid={containerTestId}
       aria-live="polite"
       aria-busy={styleOptions.enableAnimation ?? defaultEnableAnimation}
+      style={containerStyle}
     >
       {Wrapper
         ? elements.map((el, i) => <Wrapper key={i}>{el}</Wrapper>)

--- a/src/__tests__/Skeleton.test.tsx
+++ b/src/__tests__/Skeleton.test.tsx
@@ -150,3 +150,20 @@ it('renders a 3/4-width skeleton when count = 1.75 and width is set in pixels', 
   expect(skeletons[0]).toHaveStyle({ width: '100px' });
   expect(skeletons[1]).toHaveStyle({ width: '75px' });
 });
+
+it('include width:100% in container style because of a full-width skeleton when width is one of null, undefined, 100%', () => {
+  const { rerender } = render(
+    <Skeleton count={1} containerTestId="container" />
+  );
+
+  const skeletons = getAllSkeletons();
+  expect(skeletons).toHaveLength(1);
+
+  const container = screen.getByTestId('container');
+  expect(container).toHaveStyle({ width: '100%' });
+
+  rerender(<Skeleton count={1} containerTestId="container" width="100%" />);
+
+  expect(skeletons).toHaveLength(1);
+  expect(container).toHaveStyle({ width: '100%' });
+});


### PR DESCRIPTION
Hello, thanks for your library.
I found an issue while redering Skeleton when width param is nullable.

![스크린샷 2023-04-07 오전 4 49 55](https://user-images.githubusercontent.com/48472989/230480371-1f2ae230-409e-42da-bbab-e8fcf5a58144.png)

The photo above is the result of ```<Skeleton count={1}/>```
**Span element with class react-loading-skeleton has width:100% style, but skeleton is not rendered.
(It works fine in storybook, I guess it's because of style used inside storybook.)**
This is because the parent span(aka. container) of the span with class react-loading-skeleton does not have a width style.

![스크린샷 2023-04-07 오전 4 56 54](https://user-images.githubusercontent.com/48472989/230481618-1625bffd-bb0b-4883-8775-14807ddeaf0b.png)

**I tried putting width:100% style in the parent span and it was resolved.**
![스크린샷 2023-04-07 오전 4 59 56](https://user-images.githubusercontent.com/48472989/230482151-ca5f0783-ade3-47e8-8dc2-24846bc350fa.png)

Therefore, when the width param is Nullable, width:100% is added to the container span.
I additionally added some test code and all passed.

Thanks.
