### PR TITLE
add user-select: none

### DIFF
--- a/src/skeleton.css
+++ b/src/skeleton.css
@@ -19,6 +19,7 @@
   line-height: 1;
 
   position: relative;
+  user-select: none;
   overflow: hidden;
   z-index: 1; /* Necessary for overflow: hidden to work correctly in Safari */
 }


### PR DESCRIPTION
When "selecting all" on a page, the skeletons are also selected.

![image](https://user-images.githubusercontent.com/6906782/231451489-a4b5fee7-d32b-4dd9-b009-5c53bf320f74.png)

Copy, then paste
```
‌‌‌‌
‌‌‌‌
‌‌‌‌
‌‌‌‌
→
Some text for comparison
Some text for comparison
Some text for comparison
Some text for comparison
```

That's a lot of whitespace.

**After adding user-select: none**
![image](https://user-images.githubusercontent.com/6906782/231451553-f98c4979-8350-41e6-8346-b69dae655582.png)

Copy, then paste
```
→
Some text for comparison
Some text for comparison
Some text for comparison
Some text for comparison
```