### PR TITLE
Fix typescript module nodenext compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install react-loading-skeleton
 ```
 
 ```tsx
-import Skeleton from 'react-loading-skeleton'
+import { Skeleton } from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
 
 <Skeleton /> // Simple, single-line loading skeleton
@@ -82,7 +82,7 @@ Customize individual skeletons with props, or render a `SkeletonTheme` to style
 all skeletons below it in the React hierarchy:
 
 ```tsx
-import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
+import { Skeleton, SkeletonTheme } from 'react-loading-skeleton';
 
 return (
   <SkeletonTheme baseColor="#202020" highlightColor="#444">

--- a/package.json
+++ b/package.json
@@ -21,6 +21,14 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./dist/skeleton.css": "./dist/skeleton.css"
+  },
   "files": [
     "dist/"
   ],

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Skeleton, { SkeletonTheme, SkeletonThemeProps, SkeletonProps } from '..';
+import { Skeleton, SkeletonTheme, SkeletonThemeProps, SkeletonProps } from '..';
 
 it('exports Skeleton and friends', () => {
   expect(typeof Skeleton).toBe('function');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import { Skeleton } from './Skeleton';
+export { Skeleton } from './Skeleton';
 
-export default Skeleton;
 export * from './SkeletonStyleProps';
 export * from './SkeletonTheme';
 export type { SkeletonProps } from './Skeleton';


### PR DESCRIPTION
This PR fixes #181 

Warning: I changed the exports from default export to named export which is a breaking change. 
An alternative to a breaking change would be to keep both named and default exports but may be confusing for the package user to figure out which export to use.