### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Using a `<SkeletonTheme>` component, you can easily change the colors of all
 skeleton components below it in the React hierarchy:
 
 ```javascript
+import "react-loading-skeleton/dist/skeleton.css";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 
 <SkeletonTheme color="#202020" highlightColor="#444">


### PR DESCRIPTION
I spent a long time searching because the skeleton was not shown, the reason was because it imported the css styles.

import "react-loading-skeleton/dist/skeleton.css";