### PR TITLE
Update skeleton.css - using new animation color defaults

### DIFF
--- a/src/skeleton.css
+++ b/src/skeleton.css
@@ -5,8 +5,8 @@
 }
 
 .react-loading-skeleton {
-  --base-color: #ebebeb;
-  --highlight-color: #f5f5f5;
+  --base-color: ##202020;
+  --highlight-color: #444;
   --animation-duration: 1.5s;
   --animation-direction: normal;
   --pseudo-element-display: block; /* Enable animation */


### PR DESCRIPTION
Using more contrasty defaults, per your README example settings for the SkeletonTheme. The former defaults make the animation effect too subtle on my monitor