### PR TITLE
Remove `z-index: 1` because it is no longer necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.4.0
+
+### Features
+
+- Remove `z-index: 1` from the skeleton. This was a Safari-specific workaround that is no longer necessary in the latest versions of the browser. (#216)
+
 ## 3.3.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-loading-skeleton",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Make beautiful, animated loading skeletons that automatically adapt to your app.",
   "keywords": [
     "react",

--- a/src/skeleton.css
+++ b/src/skeleton.css
@@ -21,7 +21,6 @@
   position: relative;
   user-select: none;
   overflow: hidden;
-  z-index: 1; /* Necessary for overflow: hidden to work correctly in Safari */
 }
 
 .react-loading-skeleton::after {


### PR DESCRIPTION
Fixes #216.

I will test this on macOS on Monday, and then merge it.